### PR TITLE
Fix capitalisation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Update `config/app.php` by adding the LastfmServiceProvider:
 ```php
 'providers' => [
     ...
-    Barryvanveen\Lastfm\LastfmServiceprovider::class,
+    Barryvanveen\Lastfm\LastfmServiceProvider::class,
 ];
 ```
 


### PR DESCRIPTION
The readme contains a capitalisation error which causes the Laravel service provider not te be loaded.